### PR TITLE
Add github actions for linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,8 @@ on: push
 
 jobs:
   lint:
+    runs-on: ubuntu-latest
+
     strategy:
       matrix:
         node-version: ['18.x', '20.x']

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Run Checks
+
+on: push
+
+jobs:
+  lint:
+    strategy:
+      matrix:
+        node-version: ['18.x', '20.x']
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Run prettier
+        run: npm run prettier
+      - name: Run eslint
+        run: npm run lint


### PR DESCRIPTION
Closes #3 

This PR adds Github Actions for checking the linter and prettier on Node 18 and 20. 

We probably don't need to run it on multiple versions of node, but we might want to do something similar for different versions of typescript in the future.