### PR TITLE
added clause support for jsonb paths

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -49,7 +49,7 @@ type SqlOp<S extends SqlOps> = {
 
 export type Logic = OneOf<[SqlOp<'*in_'>, SqlOp<'*eq'>, SqlOp<'*neq'>, SqlOp<'*contains'>, SqlOp<'*icontains'>]>;
 
-// (SM) make an type where all keys of T with '.${any string}'following them are valid keys
+// (SM) make a type where all keys of T with '.${any string}'following them are valid keys
 type Dots<T> = {
   [K in keyof T & string as `${K}.${string}`]: T[K]
 };

--- a/index.ts
+++ b/index.ts
@@ -49,10 +49,15 @@ type SqlOp<S extends SqlOps> = {
 
 export type Logic = OneOf<[SqlOp<'*in_'>, SqlOp<'*eq'>, SqlOp<'*neq'>, SqlOp<'*contains'>, SqlOp<'*icontains'>]>;
 
+// (SM) make an type where all keys of T with '.${any string}'following them are valid keys
+type Dots<T> = {
+  [K in keyof T & string as `${K}.${string}`]: T[K]
+};
+
 export type Clause<TModel> = {
-  [key in keyof TModel]: Record<key, Logic> & Partial<Record<Exclude<keyof TModel, key>, never>> extends infer O
+  [key in keyof (TModel & Dots<TModel>)]: Record<key, Logic> & Partial<Record<Exclude<keyof TModel, key>, never>> extends infer O
     ? Expand<O>
     : never;
-}[keyof TModel];
+}[keyof (TModel & Dots<TModel>)];
 
 export type Where<TModel> = LogicalGrouping<TModel> | Clause<TModel>;


### PR DESCRIPTION
When making a clause for a field that is a JSONB column in the underlying Postgres table, it's possible to dive into the json itself by using a dot separated path in the field.  For instance, you can do:
`const clause: Clause<T> = { ['expansion.some.inner.field']: { '*eq': 'some value' } };`
if `expansion` is a field of `T`.

Obviously we're not gonna type check the whole path, but this MR adds the ability to put keys like this that **_start_** with a valid key of `T` and are followed by a `.` or a `.${any string}`.  

